### PR TITLE
Fixing Argument Completer on PS3/4

### DIFF
--- a/PSFramework/functions/tabexpansion/Register-PSFTeppArgumentCompleter.ps1
+++ b/PSFramework/functions/tabexpansion/Register-PSFTeppArgumentCompleter.ps1
@@ -37,7 +37,7 @@
 		$Name
 	)
 	
-	if (($PSVersionTable["PSVersion"].Major -lt 5) -and (-not (Get-Item function:Register-ArgumentCompleter)))
+	if (($PSVersionTable["PSVersion"].Major -lt 5) -and (-not (Get-Item function:Register-ArgumentCompleter -ErrorAction Ignore)))
 	{
 		return
 	}


### PR DESCRIPTION
Was failing in PS3/4 when strict mode was enabled due to exception
fixes: https://github.com/PowershellFrameworkCollective/psframework/issues/45