### PR TITLE
Tab Expansion Commands - Parameterization and Help

### DIFF
--- a/PSFramework/functions/tabexpansion/Register-PSFTeppArgumentCompleter.ps1
+++ b/PSFramework/functions/tabexpansion/Register-PSFTeppArgumentCompleter.ps1
@@ -16,23 +16,24 @@
         
         .PARAMETER Name
             Name of the Tepp Completioner to use.
-            Defaults to the parameter name.
-            Best practice requires a Completioner to be named the same as the completed parameter, in which case this parameter needs not be specified.
-            However sometimes that may not be universally possible, which is when this parameter comes in.
+			Use the same name as was assigned in Register-PSFTeppScriptblock (which needs to be called first).
         
         .EXAMPLE
-            Register-PSFTeppArgumentCompleter -Command Get-DbaBackupHistory -Parameter Database
+            Register-PSFTeppArgumentCompleter -Command Get-Test -Parameter Example -Name MyModule.Example
     
-            Registers the "Database" parameter of the Get-DbaBackupHistory to receive Database-Tepp
+            Registers the parameter 'Example' of the command 'Get-Test' to receive the tab completion registered to 'MyModule.Example'
     #>
 	[CmdletBinding()]
 	Param (
-		[string]
+		[Parameter(Mandatory = $true)]
+		[string[]]
 		$Command,
 		
+		[Parameter(Mandatory = $true)]
 		[string[]]
 		$Parameter,
 		
+		[Parameter(Mandatory = $true)]
 		[string]
 		$Name
 	)
@@ -42,17 +43,9 @@
 		return
 	}
 	
-	foreach ($p in $Parameter)
+	foreach ($Param in $Parameter)
 	{
-		
-		$lowername = $PSBoundParameters.Name
-		
-		if ($null -eq $lowername)
-		{
-			$lowername = $p
-		}
-		
-		$scriptBlock = [PSFramework.TabExpansion.TabExpansionHost]::Scripts[$lowername.ToLower()].ScriptBlock
-		Register-ArgumentCompleter -CommandName $Command -ParameterName $p -ScriptBlock $scriptBlock
+		$scriptBlock = [PSFramework.TabExpansion.TabExpansionHost]::Scripts[$Name.ToLower()].ScriptBlock
+		Register-ArgumentCompleter -CommandName $Command -ParameterName $Param -ScriptBlock $scriptBlock
 	}
 }

--- a/PSFramework/functions/tabexpansion/Register-PSFTeppScriptblock.ps1
+++ b/PSFramework/functions/tabexpansion/Register-PSFTeppScriptblock.ps1
@@ -9,6 +9,11 @@
 	
 			This system supports two separate types of input: Full or Simple.
 	
+			Simple:
+			The scriptblock simply must return string values.
+			PSFramework will then do the rest of the processing when the user asks for tab completion.
+			This is the simple-most way to implement tab completion, for a full example, look at the first example in this help.
+	
 			Full:
 			A full scriptblock implements all that is needed to provide Tab Expansion.
 			For more details and guidance, see the following concept help:
@@ -19,6 +24,7 @@
         
         .PARAMETER Name
             The name under which the scriptblock should be registered.
+			It is recommended to prefix the name with the module (e.g.: mymodule.<name>), as names are shared across all implementing modules.
 	
 		.PARAMETER Mode
 			Whether the script provided is a full or simple scriptblock.
@@ -28,7 +34,7 @@
 			Register-PSFTeppScriptblock -Name "psalcohol-liquids" -ScriptBlock { "beer", "mead", "wine", "vodka", "whiskey", "rum" }
 			Register-PSFTeppArgumentCompleter -Command Get-Alcohol -Parameter Type -Name "psalcohol-liquids"
 	
-			In step one we set a list of questionable liquids as the list of available
+			In step one we set a list of questionable liquids as the list of available beverages for parameter 'Type' on the command 'Get-Alcohol'
         
         .EXAMPLE
             Register-PSFTeppScriptblock -ScriptBlock $scriptBlock -Name MyFirstTeppScriptBlock
@@ -44,9 +50,11 @@
     #>
 	[CmdletBinding()]
 	Param (
+		[Parameter(Mandatory = $true)]
 		[System.Management.Automation.ScriptBlock]
 		$ScriptBlock,
 		
+		[Parameter(Mandatory = $true)]
 		[string]
 		$Name,
 		


### PR DESCRIPTION
Updated documentation
Changed parameterization to enforce mandatory parameters for parameters that have already needed to be specified anyway