### PR TITLE
GELF Logging Provider - Removed hardcoded values for troubleshooting

### DIFF
--- a/PSFramework/internal/loggingProviders/gelf.provider.ps1
+++ b/PSFramework/internal/loggingProviders/gelf.provider.ps1
@@ -18,9 +18,9 @@ $start_event = {
     $gelf_encrypt = Get-PSFConfigValue -FullName 'PSFramework.Logging.GELF.Encrypt'
 
     $gelf_paramSendPsgelfTcp = @{
-        'GelfServer' = 'localhost'
-        'Port' = 12201
-        'Encrypt' = $false
+        'GelfServer' = $gelf_gelfserver
+        'Port' = $gelf_port
+        'Encrypt' = $gelf_encrypt
     }
 }
 


### PR DESCRIPTION
I left some values hardcoded when I was troubleshooting my Get-PSFConfigValue problem. I put them back to Get-PSFConfigValue.