### PR TITLE
Fixing issue on PS Core with Get-PSSnapin

### DIFF
--- a/PSFramework/functions/utility/New-PSFSupportPackage.ps1
+++ b/PSFramework/functions/utility/New-PSFSupportPackage.ps1
@@ -196,7 +196,7 @@ This will make it easier for us to troubleshoot and you won't be sending us the 
 			Write-PSFMessage -Level Important -Message "Collecting list of loaded modules (Get-Module)"
 			$hash["Modules"] = Get-Module
 		}
-		if (($Include -band 512) -and -not ($Exclude -band 512))
+		if ((($Include -band 512) -and -not ($Exclude -band 512)) -and (Get-Command -Name Get-PSSnapIn -ErrorAction SilentlyContinue))
 		{
 			Write-PSFMessage -Level Important -Message "Collecting list of loaded snapins (Get-PSSnapin)"
 			$hash["SnapIns"] = Get-PSSnapin


### PR DESCRIPTION
On PowerShell Core, New-PSFSupportPackage displays a CommandNotFound exception since the Get-PSSnapin Cmdlet is not available.

This PR fixes this small issue.