### PR TITLE
psd1 LicenseUri shows rename from 0699df3

### DIFF
--- a/PSFramework/PSFramework.psd1
+++ b/PSFramework/PSFramework.psd1
@@ -162,7 +162,7 @@
 			Tags = @('scripting', 'infrastructure', 'logging', 'configuration', 'PSEdition_Core', 'PSEdition_Desktop', 'Linux', 'Mac')
 			
 			# A URL to the license for this module.
-			LicenseUri = 'https://github.com/PowershellFrameworkCollective/psframework/blob/master/LICENSE.md'
+			LicenseUri = 'https://github.com/PowershellFrameworkCollective/psframework/blob/master/LICENSE'
 			
 			# A URL to the main website for this project.
 			ProjectUri = 'http://psframework.org'


### PR DESCRIPTION
the PSGallery license link is black-holing on the `.md` license extension following the rename at 0699df30dbf6cc2406785cef3aa10505d0669b6b

<img width="631" alt="PSGallery License Info tooltip" src="https://user-images.githubusercontent.com/10898767/70438994-f06f7e80-1a86-11ea-8361-8876b2b016d1.png">

