### PR TITLE
Eliminate string instantiation for comparison

### DIFF
--- a/PSFramework/functions/configuration/Register-PSFConfig.ps1
+++ b/PSFramework/functions/configuration/Register-PSFConfig.ps1
@@ -194,9 +194,9 @@
 					
 					foreach ($item in $FullName)
 					{
-						if ([PSFramework.Configuration.ConfigurationHost]::Configurations.ContainsKey($item.ToLower()))
+						if ([PSFramework.Configuration.ConfigurationHost]::Configurations.ContainsKey($item))
 						{
-							Write-Config -Config ([PSFramework.Configuration.ConfigurationHost]::Configurations[$item.ToLower()]) -Scope $Scope -EnableException $EnableException
+							Write-Config -Config ([PSFramework.Configuration.ConfigurationHost]::Configurations[$item]) -Scope $Scope -EnableException $EnableException
 						}
 					}
 				}
@@ -225,9 +225,9 @@
 					
 					foreach ($item in $FullName)
 					{
-						if (($configurationItems.FullName -notcontains $item) -and ([PSFramework.Configuration.ConfigurationHost]::Configurations.ContainsKey($item.ToLower())))
+						if (($configurationItems.FullName -notcontains $item) -and ([PSFramework.Configuration.ConfigurationHost]::Configurations.ContainsKey($item)))
 						{
-							$configurationItems += [PSFramework.Configuration.ConfigurationHost]::Configurations[$item.ToLower()]
+							$configurationItems += [PSFramework.Configuration.ConfigurationHost]::Configurations[$item]
 						}
 					}
 				}

--- a/PSFramework/functions/configuration/Register-PSFConfigValidation.ps1
+++ b/PSFramework/functions/configuration/Register-PSFConfigValidation.ps1
@@ -37,5 +37,5 @@
 		$ScriptBlock
 	)
 	
-	[PSFramework.Configuration.ConfigurationHost]::Validation[$Name.ToLower()] = $ScriptBlock
+	[PSFramework.Configuration.ConfigurationHost]::Validation[$Name] = $ScriptBlock
 }

--- a/PSFramework/functions/import/Register-PSFParameterClassMapping.ps1
+++ b/PSFramework/functions/import/Register-PSFParameterClassMapping.ps1
@@ -59,19 +59,19 @@
 			{
 				"Computer"
 				{
-					[PSFramework.Parameter.ComputerParameter]::SetTypePropertyMapping($TypeName.ToLower(), $Properties)
+					[PSFramework.Parameter.ComputerParameter]::SetTypePropertyMapping($TypeName, $Properties)
 				}
 				"DateTime"
 				{
-					[PSFramework.Parameter.DateTimeParameter]::SetTypePropertyMapping($TypeName.ToLower(), $Properties)
+					[PSFramework.Parameter.DateTimeParameter]::SetTypePropertyMapping($TypeName, $Properties)
 				}
 				"TimeSpan"
 				{
-					[PSFramework.Parameter.TimeSpanParameter]::SetTypePropertyMapping($TypeName.ToLower(), $Properties)
+					[PSFramework.Parameter.TimeSpanParameter]::SetTypePropertyMapping($TypeName, $Properties)
 				}
 				"Encoding"
 				{
-					[PSFramework.Parameter.EncodingParameter]::SetTypePropertyMapping($TypeName.ToLower(), $Properties)
+					[PSFramework.Parameter.EncodingParameter]::SetTypePropertyMapping($TypeName, $Properties)
 				}
 				default
 				{

--- a/PSFramework/functions/logging/Install-PSFLoggingProvider.ps1
+++ b/PSFramework/functions/logging/Install-PSFLoggingProvider.ps1
@@ -45,22 +45,22 @@
 	
 	dynamicparam
 	{
-		if ($Name -and ([PSFramework.Logging.ProviderHost]::Providers.ContainsKey($Name.ToLower())))
+		if ($Name -and ([PSFramework.Logging.ProviderHost]::Providers.ContainsKey($Name)))
 		{
-			[PSFramework.Utility.UtilityHost]::ImportScriptBlock([PSFramework.Logging.ProviderHost]::Providers[$Name.ToLower()].InstallationParameters)
-			[PSFramework.Logging.ProviderHost]::Providers[$Name.ToLower()].InstallationParameters.Invoke()
+			[PSFramework.Utility.UtilityHost]::ImportScriptBlock([PSFramework.Logging.ProviderHost]::Providers[$Name].InstallationParameters)
+			[PSFramework.Logging.ProviderHost]::Providers[$Name].InstallationParameters.Invoke()
 		}
 	}
 	
 	process
 	{
-		if (-not ([PSFramework.Logging.ProviderHost]::Providers.ContainsKey($Name.ToLower())))
+		if (-not ([PSFramework.Logging.ProviderHost]::Providers.ContainsKey($Name)))
 		{
 			Stop-PSFFunction -Message "Provider $Name not found!" -EnableException $EnableException -Category InvalidArgument -Target $Name -Tag 'logging', 'provider', 'install'
 			return
 		}
 		
-		$provider = [PSFramework.Logging.ProviderHost]::Providers[$Name.ToLower()]
+		$provider = [PSFramework.Logging.ProviderHost]::Providers[$Name]
 		[PSFramework.Utility.UtilityHost]::ImportScriptBlock($provider.IsInstalledScript)
 		[PSFramework.Utility.UtilityHost]::ImportScriptBlock($provider.InstallationScript)
 		

--- a/PSFramework/functions/logging/Register-PSFLoggingProvider.ps1
+++ b/PSFramework/functions/logging/Register-PSFLoggingProvider.ps1
@@ -230,7 +230,7 @@
 		$EnableException
 	)
 	
-	if ([PSFramework.Logging.ProviderHost]::Providers.ContainsKey($Name.ToLower()))
+	if ([PSFramework.Logging.ProviderHost]::Providers.ContainsKey($Name))
 	{
 		return
 	}
@@ -267,7 +267,7 @@
 			
 			$provider.InstallationOptional = Get-PSFConfigValue -FullName "LoggingProvider.$Name.InstallOptional" -Fallback $false
 			
-			[PSFramework.Logging.ProviderHost]::Providers[$Name.ToLower()] = $provider
+			[PSFramework.Logging.ProviderHost]::Providers[$Name] = $provider
 		}
 		#endregion Implement Version 1 Logging Provider (legacy)
 		
@@ -308,7 +308,7 @@
 			$provider.InstallationParameters = $InstallationParameters
 			$provider.InstallationOptional = Get-PSFConfigValue -FullName "LoggingProvider.$Name.InstallOptional" -Fallback $false
 			
-			[PSFramework.Logging.ProviderHost]::Providers[$Name.ToLower()] = $provider
+			[PSFramework.Logging.ProviderHost]::Providers[$Name] = $provider
 		}
 		#endregion Implement Version 2 Logging Provider
 	}
@@ -318,7 +318,7 @@
 	catch
 	{
 		$dummy = $null
-		$null = [PSFramework.Logging.ProviderHost]::Providers.TryRemove($Name.ToLower(), [ref] $dummy)
+		$null = [PSFramework.Logging.ProviderHost]::Providers.TryRemove($Name, [ref] $dummy)
 		Stop-PSFFunction -Message "Failed to register logging provider '$Name' - Registration event failed." -ErrorRecord $_ -EnableException $EnableException -Tag 'logging', 'provider', 'fail', 'register'
 		return
 	}

--- a/PSFramework/functions/message/Register-PSFMessageTransform.ps1
+++ b/PSFramework/functions/message/Register-PSFMessageTransform.ps1
@@ -106,8 +106,8 @@
 	
 	process
 	{
-		if ($TargetType) { [PSFramework.Message.MessageHost]::TargetTransforms[$TargetType.ToLower()] = $ScriptBlock }
-		if ($ExceptionType) { [PSFramework.Message.MessageHost]::ExceptionTransforms[$ExceptionType.ToLower()] = $ScriptBlock }
+		if ($TargetType) { [PSFramework.Message.MessageHost]::TargetTransforms[$TargetType] = $ScriptBlock }
+		if ($ExceptionType) { [PSFramework.Message.MessageHost]::ExceptionTransforms[$ExceptionType] = $ScriptBlock }
 		
 		if ($TargetTypeFilter)
 		{

--- a/PSFramework/functions/message/Remove-PSFMessageLevelModifier.ps1
+++ b/PSFramework/functions/message/Remove-PSFMessageLevelModifier.ps1
@@ -51,10 +51,10 @@
 		{
 			if ($item -eq "PSFramework.Message.MessageLevelModifier") { continue }
 			
-			if ([PSFramework.Message.MessageHost]::MessageLevelModifiers.ContainsKey($item.ToLower()))
+			if ([PSFramework.Message.MessageHost]::MessageLevelModifiers.ContainsKey($item))
 			{
 				$dummy = $null
-				$null = [PSFramework.Message.MessageHost]::MessageLevelModifiers.TryRemove($item.ToLower(), [ref] $dummy)
+				$null = [PSFramework.Message.MessageHost]::MessageLevelModifiers.TryRemove($item, [ref] $dummy)
 			}
 			else
 			{

--- a/PSFramework/functions/runspace/Register-PSFRunspace.ps1
+++ b/PSFramework/functions/runspace/Register-PSFRunspace.ps1
@@ -56,14 +56,14 @@
 		$NoMessage
 	)
 	
-	if ([PSFramework.Runspace.RunspaceHost]::Runspaces.ContainsKey($Name.ToLower()))
+	if ([PSFramework.Runspace.RunspaceHost]::Runspaces.ContainsKey($Name)
 	{
-		if (-not $NoMessage) { Write-PSFMessage -Level Verbose -Message "Updating runspace: <c='em'>$($Name.ToLower())</c>" -Target $Name.ToLower() -Tag 'runspace','register' }
-		[PSFramework.Runspace.RunspaceHost]::Runspaces[$Name.ToLower()].SetScript($ScriptBlock)
+		if (-not $NoMessage) { Write-PSFMessage -Level Verbose -Message "Updating runspace: <c='em'>$($Name)</c>" -Target $Name -Tag 'runspace','register' }
+		[PSFramework.Runspace.RunspaceHost]::Runspaces[$Name].SetScript($ScriptBlock)
 	}
 	else
 	{
-		if (-not $NoMessage) { Write-PSFMessage -Level Verbose -Message "Registering runspace: <c='em'>$($Name.ToLower())</c>" -Target $Name.ToLower() -Tag 'runspace', 'register' }
-		[PSFramework.Runspace.RunspaceHost]::Runspaces[$Name.ToLower()] = New-Object PSFramework.Runspace.RunspaceContainer($Name.ToLower(), $ScriptBlock)
+		if (-not $NoMessage) { Write-PSFMessage -Level Verbose -Message "Registering runspace: <c='em'>$($Name)</c>" -Target $Name -Tag 'runspace', 'register' }
+		[PSFramework.Runspace.RunspaceHost]::Runspaces[$Name] = New-Object PSFramework.Runspace.RunspaceContainer($Name, $ScriptBlock)
 	}
 }

--- a/PSFramework/functions/runspace/Start-PSFRunspace.ps1
+++ b/PSFramework/functions/runspace/Start-PSFRunspace.ps1
@@ -57,24 +57,24 @@
 			# Ignore all output from Get-PSFRunspace - it'll be handled by the second loop
 			if ($item -eq "psframework.runspace.runspacecontainer") { continue }
 			
-			if ([PSFramework.Runspace.RunspaceHost]::Runspaces.ContainsKey($item.ToLower()))
+			if ([PSFramework.Runspace.RunspaceHost]::Runspaces.ContainsKey($item))
 			{
 				if ($PSCmdlet.ShouldProcess($item, "Starting Runspace"))
 				{
 					try
 					{
-						if (-not $NoMessage) { Write-PSFMessage -Level Verbose -Message "Starting runspace: <c='em'>$($item.ToLower())</c>" -Target $item.ToLower() -Tag "runspace", "start" }
-						[PSFramework.Runspace.RunspaceHost]::Runspaces[$item.ToLower()].Start()
+						if (-not $NoMessage) { Write-PSFMessage -Level Verbose -Message "Starting runspace: <c='em'>$($item)</c>" -Target $item -Tag "runspace", "start" }
+						[PSFramework.Runspace.RunspaceHost]::Runspaces[$item.].Start()
 					}
 					catch
 					{
-						Stop-PSFFunction -Message "Failed to start runspace: <c='em'>$($item.ToLower())</c>" -ErrorRecord $_ -EnableException $EnableException -Tag "fail", "argument", "runspace", "start" -Target $item.ToLower() -Continue
+						Stop-PSFFunction -Message "Failed to start runspace: <c='em'>$($item)</c>" -ErrorRecord $_ -EnableException $EnableException -Tag "fail", "argument", "runspace", "start" -Target $item -Continue
 					}
 				}
 			}
 			else
 			{
-				Stop-PSFFunction -Message "Failed to start runspace: <c='em'>$($item.ToLower())</c> | No runspace registered under this name!" -EnableException $EnableException -Category InvalidArgument -Tag "fail", "argument", "runspace", "start" -Target $item.ToLower() -Continue
+				Stop-PSFFunction -Message "Failed to start runspace: <c='em'>$($item)</c> | No runspace registered under this name!" -EnableException $EnableException -Category InvalidArgument -Tag "fail", "argument", "runspace", "start" -Target $item -Continue
 			}
 		}
 		
@@ -84,12 +84,12 @@
 			{
 				try
 				{
-					if (-not $NoMessage) { Write-PSFMessage -Level Verbose -Message "Starting runspace: <c='em'>$($item.Name.ToLower())</c>" -Target $item -Tag "runspace", "start" }
+					if (-not $NoMessage) { Write-PSFMessage -Level Verbose -Message "Starting runspace: <c='em'>$($item.Name)</c>" -Target $item -Tag "runspace", "start" }
 					$item.Start()
 				}
 				catch
 				{
-					Stop-PSFFunction -Message "Failed to start runspace: <c='em'>$($item.Name.ToLower())</c>" -EnableException $EnableException -Tag "fail", "argument", "runspace", "start" -Target $item -Continue
+					Stop-PSFFunction -Message "Failed to start runspace: <c='em'>$($item.Name)</c>" -EnableException $EnableException -Tag "fail", "argument", "runspace", "start" -Target $item -Continue
 				}
 			}
 		}

--- a/PSFramework/functions/runspace/Stop-PSFRunspace.ps1
+++ b/PSFramework/functions/runspace/Stop-PSFRunspace.ps1
@@ -60,24 +60,24 @@
 			# Ignore all output from Get-PSFRunspace - it'll be handled by the second loop
 			if ($item -eq "psframework.runspace.runspacecontainer") { continue }
 			
-			if ([PSFramework.Runspace.RunspaceHost]::Runspaces.ContainsKey($item.ToLower()))
+			if ([PSFramework.Runspace.RunspaceHost]::Runspaces.ContainsKey($item))
 			{
 				if ($PSCmdlet.ShouldProcess($item, "Stopping Runspace"))
 				{
 					try
 					{
-						Write-PSFMessage -Level Verbose -Message "Stopping runspace: <c='em'>$($item.ToLower())</c>" -Target $item.ToLower() -Tag "runspace", "stop"
-						[PSFramework.Runspace.RunspaceHost]::Runspaces[$item.ToLower()].Stop()
+						Write-PSFMessage -Level Verbose -Message "Stopping runspace: <c='em'>$($item)</c>" -Target $item -Tag "runspace", "stop"
+						[PSFramework.Runspace.RunspaceHost]::Runspaces[$item].Stop()
 					}
 					catch
 					{
-						Stop-PSFFunction -Message "Failed to stop runspace: <c='em'>$($item.ToLower())</c>" -EnableException $EnableException -Tag "fail", "argument", "runspace", "stop" -Target $item.ToLower() -Continue -ErrorRecord $_
+						Stop-PSFFunction -Message "Failed to stop runspace: <c='em'>$($item)</c>" -EnableException $EnableException -Tag "fail", "argument", "runspace", "stop" -Target $item -Continue -ErrorRecord $_
 					}
 				}
 			}
 			else
 			{
-				Stop-PSFFunction -Message "Failed to stop runspace: <c='em'>$($item.ToLower())</c> | No runspace registered under this name!" -EnableException $EnableException -Category InvalidArgument -Tag "fail", "argument", "runspace", "stop" -Target $item.ToLower() -Continue
+				Stop-PSFFunction -Message "Failed to stop runspace: <c='em'>$($item)</c> | No runspace registered under this name!" -EnableException $EnableException -Category InvalidArgument -Tag "fail", "argument", "runspace", "stop" -Target $item -Continue
 			}
 		}
 		
@@ -87,12 +87,12 @@
 			{
 				try
 				{
-					Write-PSFMessage -Level Verbose -Message "Stopping runspace: <c='em'>$($item.Name.ToLower())</c>" -Target $item -Tag "runspace", "stop"
+					Write-PSFMessage -Level Verbose -Message "Stopping runspace: <c='em'>$($item.Name)</c>" -Target $item -Tag "runspace", "stop"
 					$item.Stop()
 				}
 				catch
 				{
-					Stop-PSFFunction -Message "Failed to stop runspace: <c='em'>$($item.Name.ToLower())</c>" -EnableException $EnableException -Tag "fail", "argument", "runspace", "stop" -Target $item -Continue -ErrorRecord $_
+					Stop-PSFFunction -Message "Failed to stop runspace: <c='em'>$($item.Name)</c>" -EnableException $EnableException -Tag "fail", "argument", "runspace", "stop" -Target $item -Continue -ErrorRecord $_
 				}
 			}
 		}

--- a/PSFramework/functions/tabexpansion/Register-PSFTeppArgumentCompleter.ps1
+++ b/PSFramework/functions/tabexpansion/Register-PSFTeppArgumentCompleter.ps1
@@ -45,7 +45,7 @@
 	
 	foreach ($Param in $Parameter)
 	{
-		$scriptBlock = [PSFramework.TabExpansion.TabExpansionHost]::Scripts[$Name.ToLower()].ScriptBlock
+		$scriptBlock = [PSFramework.TabExpansion.TabExpansionHost]::Scripts[$Name].ScriptBlock
 		Register-ArgumentCompleter -CommandName $Command -ParameterName $Param -ScriptBlock $scriptBlock
 	}
 }

--- a/PSFramework/functions/taskengine/Register-PSFTaskEngineTask.ps1
+++ b/PSFramework/functions/taskengine/Register-PSFTaskEngineTask.ps1
@@ -98,9 +98,9 @@
 	)
 	
 	#region Case: Task already registered
-	if ([PSFramework.TaskEngine.TaskHost]::Tasks.ContainsKey($Name.ToLower()))
+	if ([PSFramework.TaskEngine.TaskHost]::Tasks.ContainsKey($Name))
 	{
-		$task = [PSFramework.TaskEngine.TaskHost]::Tasks[$Name.ToLower()]
+		$task = [PSFramework.TaskEngine.TaskHost]::Tasks[$Name]
 		if (Test-PSFParameterBinding -ParameterName Description) { $task.Description = $Description}
 		if ($task.ScriptBlock -ne $ScriptBlock) { $task.ScriptBlock = $ScriptBlock }
 		if (Test-PSFParameterBinding -ParameterName Once) { $task.Once = $Once }
@@ -141,7 +141,7 @@
 		if (Test-PSFParameterBinding -ParameterName Delay) { $task.Delay = $Delay }
 		$task.Priority = $Priority
 		$task.Registered = Get-Date
-		[PSFramework.TaskEngine.TaskHost]::Tasks[$Name.ToLower()] = $task
+		[PSFramework.TaskEngine.TaskHost]::Tasks[$Name] = $task
 	}
 	#endregion New Task
 	

--- a/PSFramework/functions/taskengine/Test-PSFTaskEngineTask.ps1
+++ b/PSFramework/functions/taskengine/Test-PSFTaskEngineTask.ps1
@@ -24,11 +24,11 @@
 		$Name
 	)
 	
-	if (-not ([PSFramework.TaskEngine.TaskHost]::Tasks.ContainsKey($Name.ToLower())))
+	if (-not ([PSFramework.TaskEngine.TaskHost]::Tasks.ContainsKey($Name)))
 	{
 		return $false
 	}
 	
-	$task = [PSFramework.TaskEngine.TaskHost]::Tasks[$Name.ToLower()]
+	$task = [PSFramework.TaskEngine.TaskHost]::Tasks[$Name]
 	$task.LastExecution -gt $task.Registered
 }

--- a/PSFramework/internal/functions/configuration/Convert-PsfConfigValue.ps1
+++ b/PSFramework/internal/functions/configuration/Convert-PsfConfigValue.ps1
@@ -33,7 +33,7 @@
 	{
 		$index = $Value.IndexOf(":")
 		if ($index -lt 1) { throw "No type identifier found!" }
-		$type = $Value.Substring(0, $index).ToLower()
+		$type = $Value.Substring(0, $index)
 		$content = $Value.Substring($index + 1)
 		
 		switch ($type)

--- a/PSFramework/internal/functions/message/Convert-PsfMessageException.ps1
+++ b/PSFramework/internal/functions/message/Convert-PsfMessageException.ps1
@@ -39,7 +39,7 @@
 	
 	if ($null -eq $Exception) { return }
 	
-	$typeName = $Exception.GetType().FullName.ToLower()
+	$typeName = $Exception.GetType().FullName
 	
 	if ([PSFramework.Message.MessageHost]::ExceptionTransforms.ContainsKey($typeName))
 	{

--- a/PSFramework/internal/functions/message/Convert-PsfMessageTarget.ps1
+++ b/PSFramework/internal/functions/message/Convert-PsfMessageTarget.ps1
@@ -39,7 +39,7 @@
 	
 	if ($null -eq $Target) { return }
 	
-	$typeName = $Target.GetType().FullName.ToLower()
+	$typeName = $Target.GetType().FullName
 	
 	if ([PSFramework.Message.MessageHost]::TargetTransforms.ContainsKey($typeName))
 	{

--- a/PSFramework/internal/scripts/async-logging2.ps1
+++ b/PSFramework/internal/scripts/async-logging2.ps1
@@ -8,7 +8,7 @@
 		while ($true)
 		{
 			# This portion is critical to gracefully closing the script
-			if ([PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName.ToLower()].State -notlike "Running")
+			if ([PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName].State -notlike "Running")
 			{
 				break
 			}
@@ -152,7 +152,7 @@
 	finally
 	{
 		#region Flush log on exit
-		if (([PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName.ToLower()].State -like "Running") -and (-not [PSFramework.Configuration.ConfigurationHost]::Configurations["psframework.logging.disablelogflush"].Value))
+		if (([PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName].State -like "Running") -and (-not [PSFramework.Configuration.ConfigurationHost]::Configurations["psframework.logging.disablelogflush"].Value))
 		{
 			#region Start Event
 			foreach ($___provider in [PSFramework.Logging.ProviderHost]::GetInitialized())
@@ -272,7 +272,7 @@
 		if ($wasBroken) { [PSFramework.Logging.ProviderHost]::LoggingState = 'Broken' }
 		else { [PSFramework.Logging.ProviderHost]::LoggingState = 'Stopped' }
 		
-		[PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName.ToLower()].SignalStopped()
+		[PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName].SignalStopped()
 	}
 }
 

--- a/PSFramework/internal/scripts/loadConfigurationPersisted.ps1
+++ b/PSFramework/internal/scripts/loadConfigurationPersisted.ps1
@@ -9,8 +9,8 @@
 		{
 			if (-not $value.KeepPersisted) { Set-PSFConfig -FullName $value.FullName -Value $value.Value -EnableException }
 			else { Set-PSFConfig -FullName $value.FullName -PersistedValue $value.Value -PersistedType $value.Type -EnableException }
-			[PSFramework.Configuration.ConfigurationHost]::Configurations[$value.FullName.ToLower()].PolicySet = $value.Policy
-			[PSFramework.Configuration.ConfigurationHost]::Configurations[$value.FullName.ToLower()].PolicyEnforced = $value.Enforced
+			[PSFramework.Configuration.ConfigurationHost]::Configurations[$value.FullName].PolicySet = $value.Policy
+			[PSFramework.Configuration.ConfigurationHost]::Configurations[$value.FullName].PolicyEnforced = $value.Enforced
 		}
 		catch { }
 	}

--- a/PSFramework/internal/scripts/taskEngine.ps1
+++ b/PSFramework/internal/scripts/taskEngine.ps1
@@ -7,7 +7,7 @@
 		while ($true)
 		{
 			# This portion is critical to gracefully closing the script
-			if ([PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName.ToLower()].State -notlike "Running")
+			if ([PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName].State -notlike "Running")
 			{
 				break
 			}
@@ -44,7 +44,7 @@
 	catch {  }
 	finally
 	{
-		[PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName.ToLower()].SignalStopped()
+		[PSFramework.Runspace.RunspaceHost]::Runspaces[$___ScriptName].SignalStopped()
 	}
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -297,20 +297,15 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 				$path
 			)
 
-			$uniqueInputPaths = @()
+			$uniqueInputPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::InvariantCultureIgnoreCase)
 
 			# null and empty check are are already done on Path parameter at the cmdlet layer.
 			foreach ($currentPath in $path)
 			{
-				$currentInputPath = $currentPath.ToUpper()
-				if ($uniqueInputPaths.Contains($currentInputPath))
+				if (-not $uniqueInputPaths.Add($currentPath))
 				{
 					$errorMessage = ($LocalizedData.DuplicatePathFoundError -f $inputParameter, $currentPath, $inputParameter)
 					ThrowTerminatingErrorHelper "DuplicatePathFound" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $currentPath
-				}
-				else
-				{
-					$uniqueInputPaths += $currentInputPath
 				}
 			}
 		}
@@ -1443,20 +1438,15 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 				$path
 			)
 
-			$uniqueInputPaths = @()
+			$uniqueInputPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::InvariantCultureIgnoreCase)
 
 			# null and empty check are are already done on Path parameter at the cmdlet layer.
 			foreach ($currentPath in $path)
 			{
-				$currentInputPath = $currentPath.ToUpper()
-				if ($uniqueInputPaths.Contains($currentInputPath))
+				if (-not $uniqueInputPaths.Add($currentPath))
 				{
 					$errorMessage = ($LocalizedData.DuplicatePathFoundError -f $inputParameter, $currentPath, $inputParameter)
 					ThrowTerminatingErrorHelper "DuplicatePathFound" $errorMessage ([System.Management.Automation.ErrorCategory]::InvalidArgument) $currentPath
-				}
-				else
-				{
-					$uniqueInputPaths += $currentInputPath
 				}
 			}
 		}

--- a/library/PSFramework/Commands/WritePSFMessageCommand.cs
+++ b/library/PSFramework/Commands/WritePSFMessageCommand.cs
@@ -471,7 +471,7 @@ else { Write-PSFHostColor -String $___psframework__string -DefaultColor ([PSFram
                 {
                     if (!String.IsNullOrEmpty(Once))
                     {
-                        string onceName = String.Format("MessageOnce.{0}.{1}", FunctionName, Once).ToLower();
+                        string onceName = String.Format("MessageOnce.{0}.{1}", FunctionName, Once);
                         if (!(Configuration.ConfigurationHost.Configurations.ContainsKey(onceName) && (bool)Configuration.ConfigurationHost.Configurations[onceName].Value))
                         {
                             WriteWarning(_MessageStreams);
@@ -479,7 +479,7 @@ else { Write-PSFHostColor -String $___psframework__string -DefaultColor ([PSFram
 
                             Configuration.Config cfg = new Configuration.Config();
                             cfg.Module = "messageonce";
-                            cfg.Name = String.Format("{0}.{1}", FunctionName, Once).ToLower();
+                            cfg.Name = String.Format("{0}.{1}", FunctionName, Once);
                             cfg.Hidden = true;
                             cfg.Description = "Locking setting that disables further display of the specified message";
                             cfg.Value = true;
@@ -505,7 +505,7 @@ else { Write-PSFHostColor -String $___psframework__string -DefaultColor ([PSFram
                 {
                     if (!String.IsNullOrEmpty(Once))
                     {
-                        string onceName = String.Format("MessageOnce.{0}.{1}", FunctionName, Once).ToLower();
+                        string onceName = String.Format("MessageOnce.{0}.{1}", FunctionName, Once);
                         if (!(Configuration.ConfigurationHost.Configurations.ContainsKey(onceName) && (bool)Configuration.ConfigurationHost.Configurations[onceName].Value))
                         {
                             InvokeCommand.InvokeScript(false, ScriptBlock.Create(_writeHostScript), null, new object[] { _MessageHost, NoNewLine.ToBool() });
@@ -513,7 +513,7 @@ else { Write-PSFHostColor -String $___psframework__string -DefaultColor ([PSFram
 
                             Configuration.Config cfg = new Configuration.Config();
                             cfg.Module = "messageonce";
-                            cfg.Name = String.Format("{0}.{1}", FunctionName, Once).ToLower();
+                            cfg.Name = String.Format("{0}.{1}", FunctionName, Once);
                             cfg.Hidden = true;
                             cfg.Description = "Locking setting that disables further display of the specified message";
                             cfg.Value = true;
@@ -597,7 +597,7 @@ else { Write-PSFHostColor -String $___psframework__string -DefaultColor ([PSFram
             if (Item == null)
                 return null;
 
-            string lowTypeName = Item.GetType().FullName.ToLower();
+            string lowTypeName = Item.GetType().FullName;
 
             if (MessageHost.TargetTransforms.ContainsKey(lowTypeName))
             {
@@ -633,7 +633,7 @@ else { Write-PSFHostColor -String $___psframework__string -DefaultColor ([PSFram
             if (Item == null)
                 return Item;
 
-            string lowTypeName = Item.GetType().FullName.ToLower();
+            string lowTypeName = Item.GetType().FullName;
 
             if (MessageHost.ExceptionTransforms.ContainsKey(lowTypeName))
             {

--- a/library/PSFramework/Logging/Provider.cs
+++ b/library/PSFramework/Logging/Provider.cs
@@ -116,7 +116,7 @@ namespace PSFramework.Logging
             {
                 bool test = false;
                 foreach (string module in IncludeModules)
-                    if (Entry.ModuleName.ToLower() == module.ToLower())
+                    if (string.Equals(Entry.ModuleName, module, System.StringComparison.InvariantCultureIgnoreCase))
                         test = true;
 
                 if (!test)
@@ -124,7 +124,7 @@ namespace PSFramework.Logging
             }
 
             foreach(string module in ExcludeModules)
-                if (Entry.ModuleName.ToLower() == module.ToLower())
+                if (string.Equals(Entry.ModuleName, module, System.StringComparison.InvariantCultureIgnoreCase))
                     return false;
 
             if (IncludeTags.Count > 0)
@@ -153,7 +153,7 @@ namespace PSFramework.Logging
             {
                 bool test = false;
                 foreach (string module in IncludeModules)
-                    if (Record.ModuleName.ToLower() == module.ToLower())
+                    if (string.Equals(Record.ModuleName, module, System.StringComparison.InvariantCultureIgnoreCase))
                         test = true;
 
                 if (!test)
@@ -161,7 +161,7 @@ namespace PSFramework.Logging
             }
 
             foreach (string module in ExcludeModules)
-                if (Record.ModuleName.ToLower() == module.ToLower())
+                if (string.Equals(Record.ModuleName, module, System.StringComparison.InvariantCultureIgnoreCase))
                     return false;
 
             if (IncludeTags.Count > 0)

--- a/library/PSFramework/Logging/ProviderInstance.cs
+++ b/library/PSFramework/Logging/ProviderInstance.cs
@@ -153,7 +153,7 @@ namespace PSFramework.Logging
             {
                 bool test = false;
                 foreach (string module in IncludeModules)
-                    if (Entry.ModuleName.ToLower() == module.ToLower())
+                    if (string.Equals(Entry.ModuleName, module, StringComparison.InvariantCultureIgnoreCase))
                         test = true;
 
                 if (!test)
@@ -161,7 +161,7 @@ namespace PSFramework.Logging
             }
 
             foreach (string module in ExcludeModules)
-                if (Entry.ModuleName.ToLower() == module.ToLower())
+                if (string.Equals(Entry.ModuleName, module, StringComparison.InvariantCultureIgnoreCase))
                     return false;
 
             if (IncludeTags.Count > 0)
@@ -190,7 +190,7 @@ namespace PSFramework.Logging
             {
                 bool test = false;
                 foreach (string module in IncludeModules)
-                    if (Record.ModuleName.ToLower() == module.ToLower())
+                    if (string.Equals(Record.ModuleName, module, StringComparison.InvariantCultureIgnoreCase))
                         test = true;
 
                 if (!test)
@@ -198,7 +198,7 @@ namespace PSFramework.Logging
             }
 
             foreach (string module in ExcludeModules)
-                if (Record.ModuleName.ToLower() == module.ToLower())
+                if (string.Equals(Record.ModuleName, module, StringComparison.InvariantCultureIgnoreCase))
                     return false;
 
             if (IncludeTags.Count > 0)

--- a/library/PSFramework/Message/MessageHost.cs
+++ b/library/PSFramework/Message/MessageHost.cs
@@ -133,12 +133,12 @@ namespace PSFramework.Message
         /// <summary>
         /// Provides the option to transform exceptions based on the original exception type
         /// </summary>
-        public static ConcurrentDictionary<string, ScriptBlock> ExceptionTransforms = new ConcurrentDictionary<string, ScriptBlock>();
+        public static ConcurrentDictionary<string, ScriptBlock> ExceptionTransforms = new ConcurrentDictionary<string, ScriptBlock>(StringComparer.InvariantCultureIgnoreCase);
 
         /// <summary>
         /// Provides the option to transform target objects based on type. This is sometimes important when working with live state objects that should not be serialized.
         /// </summary>
-        public static ConcurrentDictionary<string, ScriptBlock> TargetTransforms = new ConcurrentDictionary<string, ScriptBlock>();
+        public static ConcurrentDictionary<string, ScriptBlock> TargetTransforms = new ConcurrentDictionary<string, ScriptBlock>(StringComparer.InvariantCultureIgnoreCase);
 
         /// <summary>
         /// The list of transformation errors that occured.
@@ -185,7 +185,7 @@ namespace PSFramework.Message
         /// <summary>
         /// List of all modifiers that apply to message levels
         /// </summary>
-        public static ConcurrentDictionary<string, MessageLevelModifier> MessageLevelModifiers = new ConcurrentDictionary<string, MessageLevelModifier>();
+        public static ConcurrentDictionary<string, MessageLevelModifier> MessageLevelModifiers = new ConcurrentDictionary<string, MessageLevelModifier>(StringComparer.InvariantCultureIgnoreCase);
         #endregion Transformations
 
         #region Events

--- a/library/PSFramework/Parameter/ComputerParameter.cs
+++ b/library/PSFramework/Parameter/ComputerParameter.cs
@@ -247,13 +247,13 @@ namespace PSFramework.Parameter
 
             foreach (string name in input.TypeNames)
             {
-                if (_PropertyMapping.ContainsKey(name.ToLower()))
+                if (_PropertyMapping.ContainsKey(name))
                 {
-                    key = name.ToLower();
+                    key = name;
                     break;
                 }
 
-                if (name.ToLower() == "microsoft.sqlserver.management.smo.server")
+                if (string.Equals(name, "microsoft.sqlserver.management.smo.server", StringComparison.InvariantCultureIgnoreCase))
                     Type = ComputerParameterInputType.SMOServer;
             }
 

--- a/library/PSFramework/Parameter/DateTimeParameter.cs
+++ b/library/PSFramework/Parameter/DateTimeParameter.cs
@@ -115,9 +115,9 @@ namespace PSFramework.Parameter
                     return;
                 }
 
-                if (_PropertyMapping.ContainsKey(name.ToLower()))
+                if (_PropertyMapping.ContainsKey(name))
                 {
-                    key = name.ToLower();
+                    key = name;
                     break;
                 }
             }

--- a/library/PSFramework/Parameter/EncodingParameter.cs
+++ b/library/PSFramework/Parameter/EncodingParameter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Management.Automation;
 using System.Reflection;
 using System.Text;
@@ -72,9 +73,9 @@ namespace PSFramework.Parameter
 
             foreach (string name in input.TypeNames)
             {
-                if (_PropertyMapping.ContainsKey(name.ToLower()))
+                if (_PropertyMapping.ContainsKey(name))
                 {
-                    key = name.ToLower();
+                    key = name;
                     break;
                 }
             }
@@ -95,6 +96,21 @@ namespace PSFramework.Parameter
             }
         }
 
+        private static readonly Dictionary<string, Encoding> EncodingMappings = new Dictionary<string, Encoding>(StringComparer.InvariantCultureIgnoreCase)
+        {
+            { "unicode", Encoding.Unicode },
+            { "bigendianunicode", Encoding.BigEndianUnicode },
+            { "utf8", new UTF8Encoding(true) },
+            { "utf8bom", new UTF8Encoding(true) },
+            { "utf8nobom", new UTF8Encoding(false) },
+            { "utf7", Encoding.UTF7 },
+            { "utf32", Encoding.UTF32 },
+            { "ascii", Encoding.ASCII },
+            { "default", Encoding.Default },
+            { "oem", Encoding.UTF8 },
+            { "bigendianutf32", Encoding.GetEncoding("utf-32BE") },
+        };
+
         /// <summary>
         /// Returns the correct encoding for a given string
         /// </summary>
@@ -102,33 +118,13 @@ namespace PSFramework.Parameter
         /// <returns>The encoding to retrieve.</returns>
         private Encoding GetEncoding(string Text)
         {
-            switch (Text.ToLower())
+            Encoding encoding;
+            if (EncodingMappings.TryGetValue(Text, out encoding))
             {
-                case "unicode":
-                    return Encoding.Unicode;
-                case "bigendianunicode":
-                    return Encoding.BigEndianUnicode;
-                case "utf8":
-                    return new UTF8Encoding(true);
-                case "utf8bom":
-                    return new UTF8Encoding(true);
-                case "utf8nobom":
-                    return new UTF8Encoding(false);
-                case "utf7":
-                    return Encoding.UTF7;
-                case "utf32":
-                    return Encoding.UTF32;
-                case "ascii":
-                    return Encoding.ASCII;
-                case "default":
-                    return Encoding.Default;
-                case "oem":
-                    return Encoding.UTF8;
-                case "bigendianutf32":
-                    return Encoding.GetEncoding("utf-32BE");
-                default:
-                    return Encoding.GetEncoding(Text);
+                return encoding;
             }
+
+            return Encoding.GetEncoding(Text);
         }
 
         /// <summary>

--- a/library/PSFramework/Parameter/ParameterClass.cs
+++ b/library/PSFramework/Parameter/ParameterClass.cs
@@ -26,7 +26,7 @@ namespace PSFramework.Parameter
         /// Contains the list of property mappings.
         /// Types can be registered to it, allowing the parameter class to blindly interpret unknown types
         /// </summary>
-        internal static ConcurrentDictionary<string, List<string>> _PropertyMapping = new ConcurrentDictionary<string, List<string>>();
+        internal static ConcurrentDictionary<string, List<string>> _PropertyMapping = new ConcurrentDictionary<string, List<string>>(StringComparer.InvariantCultureIgnoreCase);
 
         /// <summary>
         /// Assigns a property mapping for a given type, allowing the parameter class to handle unknown types
@@ -35,7 +35,7 @@ namespace PSFramework.Parameter
         /// <param name="PropertyName">The property names to register. When parsing input, it will move down this list until a valid property was found</param>
         public static void SetTypePropertyMapping(string Name, List<string> PropertyName)
         {
-            _PropertyMapping[Name.ToLower()] = PropertyName;
+            _PropertyMapping[Name] = PropertyName;
         }
         #endregion Static tools
 

--- a/library/PSFramework/Parameter/TimeSpanParameter.cs
+++ b/library/PSFramework/Parameter/TimeSpanParameter.cs
@@ -110,9 +110,9 @@ namespace PSFramework.Parameter
                     return;
                 }
 
-                if (_PropertyMapping.ContainsKey(name.ToLower()))
+                if (_PropertyMapping.ContainsKey(name))
                 {
-                    key = name.ToLower();
+                    key = name;
                     break;
                 }
             }

--- a/library/PSFramework/Utility/DynamicContentObject.cs
+++ b/library/PSFramework/Utility/DynamicContentObject.cs
@@ -145,7 +145,7 @@ namespace PSFramework.Utility
             this.Value = Value;
             this.Name = Name.ToLower();
 
-            Values[Name.ToLower()] = this;
+            Values[this.Name] = this;
         }
         #endregion object properties
     }

--- a/library/PSFramework/Utility/UtilityHost.cs
+++ b/library/PSFramework/Utility/UtilityHost.cs
@@ -68,11 +68,11 @@ namespace PSFramework.Utility
             {
                 if (Name == ".")
                     return true;
-                if (Name.ToLower() == "localhost")
+                if (string.Equals(Name, "localhost", StringComparison.InvariantCultureIgnoreCase))
                     return true;
-                if (Name.ToLower() == Environment.MachineName.ToLower())
+                if (string.Equals(Name, Environment.MachineName, StringComparison.InvariantCultureIgnoreCase))
                     return true;
-                if (Name.ToLower() == (Environment.MachineName + "." + Environment.GetEnvironmentVariable("USERDNSDOMAIN")).ToLower())
+                if (string.Equals(Name, (Environment.MachineName + "." + Environment.GetEnvironmentVariable("USERDNSDOMAIN")), StringComparison.InvariantCultureIgnoreCase))
                     return true;
             }
             catch { }

--- a/library/PSFramework/Validation/PsfValidateSetAttribute.cs
+++ b/library/PSFramework/Validation/PsfValidateSetAttribute.cs
@@ -105,9 +105,9 @@ namespace PSFramework.Validation
                 return results.ToArray();
             }
 
-            if (TabExpansion.TabExpansionHost.Scripts.ContainsKey(TabCompletion.ToLower()))
+            if (TabExpansion.TabExpansionHost.Scripts.ContainsKey(TabCompletion))
             {
-                return TabExpansion.TabExpansionHost.Scripts[TabCompletion.ToLower()].Invoke();
+                return TabExpansion.TabExpansionHost.Scripts[TabCompletion].Invoke();
             }
 
             return new string[0];


### PR DESCRIPTION
Invoking `ToLower` or `ToUpper` just for comparison causes unnecessary work from the garbage collector.

The recommended way is to use a method with an overload receiving a `StringComparison` value or use a `StringComparer` comparer.