### PR TITLE
1.7.249

### DIFF
--- a/PSFramework/PSFramework.psd1
+++ b/PSFramework/PSFramework.psd1
@@ -4,7 +4,7 @@
 	RootModule = 'PSFramework.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.7.247'
+	ModuleVersion = '1.7.249'
 	
 	# ID used to uniquely identify this module
 	GUID = '8028b914-132b-431f-baa9-94a6952f21ff'
@@ -43,7 +43,9 @@
 		'ConvertFrom-PSFArray'
 		'ConvertFrom-PSFClixml'
 		'ConvertTo-PSFClixml'
+		'Disable-PSFConsoleInterrupt'
 		'Disable-PSFTaskEngineTask'
+		'Enable-PSFConsoleInterrupt'
 		'Enable-PSFTaskEngineTask'
 		'Export-PSFClixml'
 		'Export-PSFConfig'

--- a/PSFramework/changelog.md
+++ b/PSFramework/changelog.md
@@ -1,5 +1,10 @@
 ﻿# CHANGELOG
 
+## 1.7.249 (2022-10-17)
+
+- New: Command Disable-PSFConsoleInterrupt - Prevents the use of CTRL+C from interrupting the console.
+- New: Command Enable-PSFConsoleInterrupt - Re-enables the use of CTRL+C to interrupt the console.
+
 ## 1.7.247 (2022-10-13)
 
 - Fix: Logging Provider: sql - does not respect the schema when creating a new table

--- a/PSFramework/functions/utility/Disable-PSFConsoleInterrupt.ps1
+++ b/PSFramework/functions/utility/Disable-PSFConsoleInterrupt.ps1
@@ -1,0 +1,22 @@
+﻿function Disable-PSFConsoleInterrupt {
+	<#
+	.SYNOPSIS
+		Prevents the use of CTRL+C from interrupting the console.
+	
+	.DESCRIPTION
+		Prevents the use of CTRL+C from interrupting the console.
+
+		Use this to prevent manual interruption of critical tasks, but do not forget to re-enable it as soon as possible.
+		Usually, ctrl+C is a critical part of the user experience, enabling the user to interrupt the console
+		and avoid a hang from locking the console.
+	
+	.EXAMPLE
+		PS C:\> Disable-PSFConsoleInterrupt
+		
+		Prevents the use of CTRL+C from interrupting the console.
+	#>
+	[CmdletBinding()]
+	param ()
+
+	[Console]::TreatControlCAsInput = $true
+}

--- a/PSFramework/functions/utility/Enable-PSFConsoleInterrupt.ps1
+++ b/PSFramework/functions/utility/Enable-PSFConsoleInterrupt.ps1
@@ -1,0 +1,18 @@
+﻿function Enable-PSFConsoleInterrupt {
+	<#
+	.SYNOPSIS
+		Re-enables the use of CTRL+C to interrupt the console.
+	
+	.DESCRIPTION
+		Re-enables the use of CTRL+C to interrupt the console.
+	
+	.EXAMPLE
+		PS C:\> Enable-PSFConsoleInterrupt
+		
+		Re-enables the use of CTRL+C to interrupt the console.
+	#>
+	[CmdletBinding()]
+	param ()
+
+	[Console]::TreatControlCAsInput = $false
+}


### PR DESCRIPTION
- New: Command Disable-PSFConsoleInterrupt - Prevents the use of CTRL+C from interrupting the console.
- New: Command Enable-PSFConsoleInterrupt - Re-enables the use of CTRL+C to interrupt the console.