### PR TITLE
1.7.249

### DIFF
--- a/PSFramework/PSFramework.psd1
+++ b/PSFramework/PSFramework.psd1
@@ -4,7 +4,7 @@
 	RootModule = 'PSFramework.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.7.246'
+	ModuleVersion = '1.7.247'
 	
 	# ID used to uniquely identify this module
 	GUID = '8028b914-132b-431f-baa9-94a6952f21ff'

--- a/PSFramework/changelog.md
+++ b/PSFramework/changelog.md
@@ -1,5 +1,9 @@
 ﻿# CHANGELOG
 
+## 1.7.247 (2022-10-13)
+
+- Fix: Logging Provider: sql - does not respect the schema when creating a new table
+
 ## 1.7.246 (2022-10-06)
 
 - Fix: Logging Provider: sql - occasional error during logging due to connection pool running out of capacity (#546)

--- a/PSFramework/internal/loggingProviders/sql.provider.ps1
+++ b/PSFramework/internal/loggingProviders/sql.provider.ps1
@@ -128,7 +128,7 @@ VALUES ($($propAdd -join ','))
 					$database = New-DbaDatabase -SqlInstance $dbaconnection -Name $SqlDatabaseName
 				}
 				if (-NOT ($database.Tables | Where-Object Name -eq $SqlTable)) {
-					$createtable = "CREATE TABLE $SqlTable (Message VARCHAR(max), Level VARCHAR(max), TimeStamp [DATETIME], FunctionName VARCHAR(max), ModuleName VARCHAR(max), Tags VARCHAR(max), Runspace VARCHAR(36), ComputerName VARCHAR(max), Username VARCHAR(max), TargetObject VARCHAR(max), [File] VARCHAR(max), Line BIGINT, ErrorRecord VARCHAR(max), CallStack VARCHAR(max), [Data] VARCHAR(max))"
+					$createtable = "CREATE TABLE $SqlSchema.$SqlTable (Message VARCHAR(max), Level VARCHAR(max), TimeStamp [DATETIME], FunctionName VARCHAR(max), ModuleName VARCHAR(max), Tags VARCHAR(max), Runspace VARCHAR(36), ComputerName VARCHAR(max), Username VARCHAR(max), TargetObject VARCHAR(max), [File] VARCHAR(max), Line BIGINT, ErrorRecord VARCHAR(max), CallStack VARCHAR(max), [Data] VARCHAR(max))"
 					Invoke-dbaquery -SQLInstance $dbaconnection -Database $SqlDatabaseName -Query $createtable
 				}
 			}


### PR DESCRIPTION
- New: Command Disable-PSFConsoleInterrupt - Prevents the use of CTRL+C from interrupting the console.
- New: Command Enable-PSFConsoleInterrupt - Re-enables the use of CTRL+C to interrupt the console.