### PR TITLE
1.7.270

### DIFF
--- a/PSFramework/PSFramework.psd1
+++ b/PSFramework/PSFramework.psd1
@@ -4,7 +4,7 @@
 	RootModule = 'PSFramework.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.7.268'
+	ModuleVersion = '1.7.270'
 	
 	# ID used to uniquely identify this module
 	GUID = '8028b914-132b-431f-baa9-94a6952f21ff'

--- a/PSFramework/changelog.md
+++ b/PSFramework/changelog.md
@@ -1,6 +1,11 @@
 ﻿# CHANGELOG
 
-## 1.7.268 (2023-02-01)
+## 1.7.270 (2023-02-06)
+
+- Upd: Import-PSFPowerShellDataFile - added parameter `Psd1Mode`, enabling psd1 files with multiple hashtables to be loaded without exposing yourself to executing unsafe code.
+- Fix: Tab Completion - fails to process hashtables for enriched Tab Completion
+
+## 1.7.268 (2023-02-06)
 
 - New: Type PsfErrorRecord - a custom error record type to provide better and easier error records.
 - Upd: Tab Completion - added support for ListItemText property on results

--- a/PSFramework/internal/scripts/teppSimpleCompleter.ps1
+++ b/PSFramework/internal/scripts/teppSimpleCompleter.ps1
@@ -102,11 +102,18 @@
 
 				$text = $entry -as [string]
 				if ($entry.PSObject.Properties.Name -contains 'Text' -and $entry.Text) { $text = $entry.Text -as [string] }
-				$toolTip = $text -as [string]
-				if ($entry.PSObject.Properties.Name -contains 'ToolTip' -and $entry.ToolTip) { $toolTip = $entry.ToolTip -as [string] }
-				$listItemText = $text -as [string]
-				if ($entry.PSObject.Properties.Name -contains 'ListItemText' -and $entry.ListItemText) { $listItemText = $entry.ListItemText -as [string] }
+				if ($entry -is [hashtable] -and $entry.Keys -contains 'Text') { $text = $entry['Text'] -as [string] }
 
+				$toolTip = $text
+				$listItemText = $text
+
+				if ($entry -is [hashtable]) {
+					if ($entry['ToolTip']) { $toolTip = $entry['ToolTip'] -as [string] }
+					if ($entry['ListItemText']) { $listItemText = $entry['ListItemText'] -as [string] }
+				}
+				
+				if ($entry.PSObject.Properties.Name -contains 'ToolTip' -and $entry.ToolTip) { $toolTip = $entry.ToolTip -as [string] }
+				if ($entry.PSObject.Properties.Name -contains 'ListItemText' -and $entry.ListItemText) { $listItemText = $entry.ListItemText -as [string] }
 				[PSCustomObject]@{
 					Text         = $text
 					ToolTip      = $toolTip


### PR DESCRIPTION
- Upd: Import-PSFPowerShellDataFile - added parameter `Psd1Mode`, enabling psd1 files with multiple hashtables to be loaded without exposing yourself to executing unsafe code.
- Fix: Tab Completion - fails to process hashtables for enriched Tab Completion