### PR TITLE
Add single GUID validator

### DIFF
--- a/PSFramework/changelog.md
+++ b/PSFramework/changelog.md
@@ -1,5 +1,9 @@
 ﻿# CHANGELOG
 
+## Unreleased
+
+- New: Configuration Validation: guid - ensures only legal guids can be added
+
 ## 1.10.318 (2023-11-10)
 
 - New: Component: Runspace Workflows - architect parallelized workflows without having to deal with the details of runspaces.

--- a/PSFramework/internal/configurationvalidation/guid.ps1
+++ b/PSFramework/internal/configurationvalidation/guid.ps1
@@ -1,0 +1,23 @@
+﻿Register-PSFConfigValidation -Name "guid" -ScriptBlock {
+	Param (
+		$Value
+	)
+	
+	$Result = [PSCustomObject]@{
+		Success = $True
+		Value   = $null
+		Message = ""
+	}
+	
+	try { [guid]$guid = $Value }
+	catch
+	{
+		$Result.Message = "Not a GUID: $Value"
+		$Result.Success = $False
+		return $Result
+	}
+	
+	$Result.Value = $guid
+	
+	return $Result
+}


### PR DESCRIPTION
Very small PR - I was missing a single GUID validator as I was not keen on allowing multiple GUIDs to be passed for certain configuration items.

As always, thank you for this module to rule all modules!