### PR TITLE
1.13.426

### DIFF
--- a/PSFramework/PSFramework.psd1
+++ b/PSFramework/PSFramework.psd1
@@ -4,7 +4,7 @@
 	RootModule = 'PSFramework.psm1'
 	
 	# Version number of this module.
-	ModuleVersion = '1.13.425'
+	ModuleVersion = '1.13.426'
 	
 	# ID used to uniquely identify this module
 	GUID = '8028b914-132b-431f-baa9-94a6952f21ff'

--- a/PSFramework/changelog.md
+++ b/PSFramework/changelog.md
@@ -1,5 +1,9 @@
 ﻿# CHANGELOG
 
+## 1.13.426 (2026-01-13)
+
+- Fix: Write-PSFHostColor - Ignores the `-NoNewLine` parameter
+
 ## 1.13.425 (2026-01-07)
 
 - New: Configuration `PSFramework.Message.Style.OldColor` - reverts update to message printing, disabling use of ANSI codes for colors

--- a/PSFramework/functions/message/Write-PSFHostColor.ps1
+++ b/PSFramework/functions/message/Write-PSFHostColor.ps1
@@ -128,7 +128,7 @@
 					foreach ($entry in $match) {
 						$row = $row -replace $entry.Groups[0].Value, "$($escape)$($colorMap[$entry.Groups[1].Value])m$($entry.Groups[2].Value)$($escape)$($defaultCode)m"
 					}
-					Microsoft.PowerShell.Utility\Write-Host -Object $row -ForegroundColor $DefaultColor
+					Microsoft.PowerShell.Utility\Write-Host -Object $row -ForegroundColor $DefaultColor -NoNewline:$NoNewLine
 					continue
 				}
 


### PR DESCRIPTION
- Fix: Write-PSFHostColor - Ignores the `-NoNewLine` parameter