### PR TITLE
prevent error: Exception setting "TreatControlCAsInput": "The handle is invalid."

### DIFF
--- a/PSFramework/functions/utility/Disable-PSFConsoleInterrupt.ps1
+++ b/PSFramework/functions/utility/Disable-PSFConsoleInterrupt.ps1
@@ -18,5 +18,5 @@
 	[CmdletBinding()]
 	param ()
 
-	[Console]::TreatControlCAsInput = $true
+	try { [Console]::TreatControlCAsInput = $true } catch {}
 }

--- a/PSFramework/functions/utility/Enable-PSFConsoleInterrupt.ps1
+++ b/PSFramework/functions/utility/Enable-PSFConsoleInterrupt.ps1
@@ -14,5 +14,5 @@
 	[CmdletBinding()]
 	param ()
 
-	[Console]::TreatControlCAsInput = $false
+	try { [Console]::TreatControlCAsInput = $false } catch {}
 }


### PR DESCRIPTION
prevent error: Exception setting "TreatControlCAsInput": "The handle is invalid."